### PR TITLE
Cleanup env usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,15 @@
 # Example of .env file. Check out 1Password for the actual values.
 
-NUR_API_HOST="common api web host"
+NUR_API_HOST=localhost
 NUR_API_PORT=8000
 
 CONFLUENCE_BASE_URL="https://<namespace>.atlassian.net/"
 CONFLUENCE_USER="user@example.com"
-CONFLUENCE_API_TOKEN="api-token"
+CONFLUENCE_API_TOKEN="???"
 
-OPENAI_API_KEY="api-key"
-OPENAI_ASSISTANT_ID_QA="assistant-id"
-OPENAI_ASSISTANT_ID_KNOWLEDGE_GAP="rag-assistant-id"
+OPENAI_API_KEY="sk-???"
+OPENAI_ASSISTANT_ID_QA="asst_???"
+OPENAI_ASSISTANT_ID_KNOWLEDGE_GAP="asst_???"
 
-SLACK_APP_TOKEN="app-token"
-SLACK_BOT_TOKEN="bot-token"
-SLACK_USER_TOKEN="user-token"
+SLACK_APP_TOKEN="xapp-???"
+SLACK_BOT_TOKEN="xoxb-???"

--- a/api/endpoint.py
+++ b/api/endpoint.py
@@ -1,5 +1,4 @@
 # ./api/endpoint.py
-import os
 from fastapi import FastAPI
 import uvicorn
 from openai import OpenAI
@@ -10,9 +9,6 @@ from pydantic import BaseModel
 from vector.chroma import vectorize_document_and_store_in_db
 from configuration import api_host, api_port
 from interactions.vectorize_and_store import vectorize_interaction_and_store_in_db
-
-host = os.environ.get("NUR_API_HOST", api_host)
-port = os.environ.get("NUR_API_PORT", api_port)
 
 processor = FastAPI()
 
@@ -93,7 +89,7 @@ def create_interaction_embeds(InteractionEmbedRequest: InteractionEmbedRequest):
 
 def main():
     """Entry point for starting the FastAPI application."""
-    uvicorn.run("api.endpoint:processor", host=host, port=int(port), reload=True)
+    uvicorn.run("api.endpoint:processor", host=api_host, port=api_port, reload=True)
 
 
 if __name__ == "__main__":

--- a/configuration.py
+++ b/configuration.py
@@ -54,7 +54,7 @@ interaction_retrieval_count = 5
 # Configuration for the Nur Services API
 # get the values from the environment variables if available or use the default values
 api_host = os.environ.get("NUR_API_HOST", "localhost")
-api_port = os.environ.get("NUR_API_PORT", "8000")
+api_port = int(os.environ.get("NUR_API_PORT", "8000"))
 
 # Name of the vector collection
 pages_collection_name = "pages"

--- a/confluence_integration/extract_page_content_and_store_processor.py
+++ b/confluence_integration/extract_page_content_and_store_processor.py
@@ -14,9 +14,6 @@ from confluence_integration.retrieve_space import process_page
 from database.page_manager import get_page_ids_missing_embeds
 
 
-host = os.environ.get("NUR_API_HOST", api_host)
-port = os.environ.get("NUR_API_PORT", api_port)
-
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -96,7 +93,7 @@ class PageProcessor:
 
 
 def submit_embedding_creation_request(page_id):
-    endpoint_url = f'http://{host}:{port}/api/v1/embeds'
+    endpoint_url = f'http://{api_host}:{api_port}/api/v1/embeds'
     headers = {"Content-Type": "application/json"}
     payload = {"page_id": page_id}
 

--- a/interactions/vectorize_and_store.py
+++ b/interactions/vectorize_and_store.py
@@ -6,10 +6,6 @@ from open_ai.embedding.embed_manager import embed_text
 from configuration import embedding_model_id
 from configuration import api_host, api_port
 import requests
-import os
-
-host = os.environ.get("NUR_API_HOST", api_host)
-port = os.environ.get("NUR_API_PORT", api_port)
 
 
 def get_qna_interactions_from_database():
@@ -130,7 +126,7 @@ def submit_create_interaction_embeds_request(interaction_id):
     :return: None
     """
 
-    endpoint_url = f'http://{host}:{port}/api/v1/interaction_embeds'
+    endpoint_url = f'http://{api_host}:{api_port}/api/v1/interaction_embeds'
     headers = {"Content-Type": "application/json"}
     # The key here should be "interaction_id" as expected by the InteractionEmbedRequest model in the FastAPI endpoint
     payload = {"interaction_id": interaction_id}

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -9,7 +9,6 @@ settings:
             OPENAI_ASSISTANT_ID_KNOWLEDGE_GAP: ENC[AES256_GCM,data:FxuyGXRQrBLbfQKATWpvx2IEt9PnbL4NrGKJRJA=,iv:rdFKdsigSrMNBkBOsyO+CZo/ZitYeJOLKUBV7681yyI=,tag:Gvgbde1neisPTVYN5KntbA==,type:str]
             SLACK_APP_TOKEN: ENC[AES256_GCM,data:ETykCin5OhzCQH61otJwYWcbOfxdgdCDk566NNpi0AsSyDLtfqsWImNvIdP4hvymetlpnkIlBXvt0rKTGL0NdAjaa97VNo0Nx2X596/uzdYlSvhAeYoyTjhNS9mMHLjNaA==,iv:NWqlVP7zQmDKCgJxZPh8r9kuW9Te4JqIDr2w2YCLcIM=,tag:MNunwFrC1dzfJuM1kFRPAg==,type:str]
             SLACK_BOT_TOKEN: ENC[AES256_GCM,data:K0X9C4LMyKkmeSAQhp2qYBonRa6VieW8ck9gVtTCR40TkTrpBAgHf5SchkLDZimJbi5MpMEL,iv:0l1+PH1dM1mzY95WVIpL9zE4do0yWlyUOQQX/9Orvpk=,tag:klkz3BMD6qt9Huk7+bsYJQ==,type:str]
-            SLACK_USER_TOKEN: ENC[AES256_GCM,data:L0mZJ78T0PaVp8OkwnxwTlwPOGCPOz0bKMtEKK1fuqxnzdQ+1BsHgEM1XCwc2UqIMYrXkJCpYIH97rfuyJFVZKuzXgk8Wskg4LAZLw==,iv:LNU3Mwt7LfzIzERkHJqsqjjvg6MQjwrGkiqch44355w=,tag:0oVWrH2d/ElyKyklhgGrQQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -19,8 +18,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-03-26T14:53:35Z"
-    mac: ENC[AES256_GCM,data:m86uEsTfQOyKc650WQP884d/w+/1jD3nATyQJ3n1J3yYIJxuyXtqW+DvQbv9hljbSZOYQx07NMk65FoaWVN+wCvrEd8qaNDsT5MtGqD6X4NM0qeI34c1NmKMucpjdnzOeHGdZCjwoANIwgAmMT5DnZ4nvWAk26IadzgJhJUHYnA=,iv:0jvrYvHdsC5FuaD0n8t88kkyCZ4lyk90fNuBn0q+IGM=,tag:xGcmWB2Pya5797/rqy156A==,type:str]
+    lastmodified: "2024-04-05T11:09:11Z"
+    mac: ENC[AES256_GCM,data:EcCVycn2kEHhBJlKDWOGpXZuGPDF7luRd4gbcvhJb4Bq4fzR8lgebsNP9xWEdEuoRb8ydURkeHb/8GHbuFyhi3nFRmsRa1ssBNyjdCXXI5WEzmSyD7JSKR0q9J1OepX62UTURVRl/XIknEd6qYcz6GibUuX565/UsZ807DcpuEg=,iv:lr55BRA9gqxuK4vBcTohhjgFycsbHN2qx862nvNfhcE=,tag:nCLw6J22unr8cANU9C87jg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/slack/channel_message_handler.py
+++ b/slack/channel_message_handler.py
@@ -7,12 +7,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode import SocketModeClient
 from configuration import api_host, api_port
 import requests
-import os
 from slack.reaction_manager import process_checkmark_added_event, process_bookmark_added_event
-
-
-host = os.environ.get("NUR_API_HOST", api_host)
-port = os.environ.get("NUR_API_PORT", api_port)
 
 
 class ChannelMessageHandler(SlackEventHandler):
@@ -103,7 +98,7 @@ class ChannelMessageHandler(SlackEventHandler):
             # publish question event to the persist queue
             try:
                 # Make an API call to publish the question
-                response = requests.post(f'http://{host}:{port}/api/v1/questions/', json=question_event)
+                response = requests.post(f'http://{api_host}:{api_port}/api/v1/questions/', json=question_event)
                 response.raise_for_status()
                 logging.info(f"Question event published: {question_event}")
 
@@ -125,7 +120,7 @@ class ChannelMessageHandler(SlackEventHandler):
             # publish feedback event to the persist queue
             try:
                 # Make an API call to publish the feedback
-                response = requests.post(f'http://{host}:{port}/api/v1/feedback/', json=feedback_event)
+                response = requests.post(f'http://{api_host}:{api_port}/api/v1/feedback/', json=feedback_event)
                 response.raise_for_status()
                 logging.info(f"Feedback published: {feedback_event}")
             except Exception as e:


### PR DESCRIPTION
* Resolve api host in port in configuration so it is not duplicated across files
* Remove unused `SLACK_USER_TOKEN` from `.env.example`
* Hint tokens format in `.env.example` to avoid confusion
* Use `localhost` as a default for `NUR_API_HOST` in `.env.example`