### PR TITLE
Require explicit slack authorization config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ OPENAI_ASSISTANT_ID_KNOWLEDGE_GAP="asst_???"
 SLACK_APP_TOKEN="xapp-???"
 SLACK_BOT_TOKEN="xoxb-???"
 SLACK_CHANNEL_ID_KNOWLEDGE_GAP_DISCUSSIONS="???"
-# Uncomment and provide values if you want to only allow interactions coming
-# from a specific Slack enterprise (organization) and/or team (workspace).
+# Only handle events coming from specific Slack enterprise (organization) and/or team (workspace)
 # Both values are optional and applied independently.
-# SLACK_REQUIRE_ENTERPRISE_ID="???"
-# SLACK_REQUIRE_TEAM_ID="???"
+# "*" means that any value would be accepted.
+SLACK_ALLOW_ENTERPRISE_ID="*"
+SLACK_ALLOW_TEAM_ID="*"

--- a/configuration.py
+++ b/configuration.py
@@ -69,5 +69,5 @@ system_confluence_knowledge_space = system_knowledge_space_private
 knowledge_gap_discussions_channel_id = os.environ.get("SLACK_CHANNEL_ID_KNOWLEDGE_GAP_DISCUSSIONS")
 
 # Authorized Slack environments
-slack_require_enterprise_id = os.environ.get("SLACK_REQUIRE_ENTERPRISE_ID", None)
-slack_require_team_id = os.environ.get("SLACK_REQUIRE_TEAM_ID", None)
+slack_allow_enterprise_id = os.environ.get("SLACK_ALLOW_ENTERPRISE_ID")
+slack_allow_team_id = os.environ.get("SLACK_ALLOW_TEAM_ID")

--- a/slack/channel_message_handler.py
+++ b/slack/channel_message_handler.py
@@ -6,7 +6,7 @@ from slack_sdk.socket_mode import SocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 
-from configuration import api_host, api_port, slack_require_enterprise_id, slack_require_team_id
+from configuration import api_host, api_port, slack_allow_enterprise_id, slack_allow_team_id
 from database.interaction_manager import QAInteractionManager
 
 from .event_handler import SlackEventHandler
@@ -43,10 +43,10 @@ class ChannelMessageHandler(SlackEventHandler):
 
     def is_authorized(self, enterprise_id: str, team_id: str) -> bool:
         """Authorize the request based on the enterprise_id and team_id"""
-        if slack_require_enterprise_id and slack_require_enterprise_id != enterprise_id:
+        if slack_allow_enterprise_id != '*' and slack_allow_enterprise_id != enterprise_id:
             return False
 
-        if slack_require_team_id and slack_require_team_id != team_id:
+        if slack_allow_team_id != '*' and slack_allow_team_id != team_id:
             return False
 
         return True


### PR DESCRIPTION
Require explicit configuration to allow slack messages from any source (used to be default behaviour if env variables are not set). This way it is more secure as misconfiguration would block interactions rather that disable authorization.